### PR TITLE
Fix meta-data retrieval for OpenStack clouds

### DIFF
--- a/scripts.d/06context
+++ b/scripts.d/06context
@@ -148,8 +148,9 @@ fetch_ec2() {
 
 
 fetch_openstack() {
-  local default_gateway=$(route | grep ^default | awk '{print $2}')
-  download_userdata $default_gateway http://${default_gateway}/latest/user-data
+  download_userdata 169.254.169.254 \
+    http://169.254.169.254/latest/user-data \
+    http://169.254.169.254/latest/meta-data/ami-id
   [ $? -eq 0 ] && UCONTEXT_SRC="OpenStack"
 }
 


### PR DESCRIPTION
It looks like the context script looks for user and metadata on openstack clouds here:

```
fetch_openstack() {
  local default_gateway=$(route | grep ^default | awk '{print $2}')
  download_userdata $default_gateway http://${default_gateway}/latest/user-data
  [ $? -eq 0 ] && UCONTEXT_SRC="OpenStack"
}
```

I've tried the route command on VMs running in various openstack clouds (UVic, CERN, GridPP). The command does not yield a valid host anywhere, at CERN for example:

```
# route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         l513-c-rbrmx-4- 0.0.0.0         UG    0      0        0 eth0
128.142.132.0   *               255.255.255.0   U     0      0        0 eth0
```

Such that default_gateway=l513-c-rbrmx-4-

The OpenStack docs specify that the meta-data server will be at http://169.254.169.254 (just like on EC2). If I read the script correctly though `fetch_ec2` should run on OpenStack (or any other environment), but isn't guaranteed to pick up the right meta-data or user-data since on OpenStack you are guaranteed http://169.254.169.254/latest but not http://169.254.169.254/2009-04-04.

Note that amazon also provides http://169.254.169.254/latest, so maybe we could simplify this?
