### PR TITLE
Remove check for user-data from cloud type determination

### DIFF
--- a/scripts.d/06context
+++ b/scripts.d/06context
@@ -141,16 +141,14 @@ fetch_gce() {
 
 fetch_ec2() {
   download_userdata 169.254.169.254 \
-    http://169.254.169.254/2009-04-04/user-data \
-    http://169.254.169.254/2009-04-04/meta-data/ami-id
+    http://169.254.169.254/latest/meta-data/ami-id
   [ $? -eq 0 ] && UCONTEXT_SRC="EC2"
 }
 
 
 fetch_openstack() {
   download_userdata 169.254.169.254 \
-    http://169.254.169.254/latest/user-data \
-    http://169.254.169.254/latest/meta-data/ami-id
+    http://169.254.169.254/openstack/latest/meta_data.json
   [ $? -eq 0 ] && UCONTEXT_SRC="OpenStack"
 }
 


### PR DESCRIPTION
The meta-data server on OpenStack and EC2 clouds only contain a user-data field if it was provided in the instance request. Thus the determination of the cloud type fails if no user-data is provided. Since we are attempting to determine the cloud type regardless of whether or not user-data has been provided (or not) I've removed the check for user-data in the context script.
