### PR TITLE
Comma fixes in JSON

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -30,7 +30,7 @@ cat << EOF > ${IMAGE}.json-metadata
 {
   "ucernvm-version": "${UVERSION}",
   "os-repo": "${OS_REPO}",
-  "snapshot": "${SNAPSHOT}",
+  "snapshot": "${SNAPSHOT}"
 }
 EOF
 cat ${IMAGE}.json-metadata /dev/zero | dd of=${IMAGE} conv=notrunc oflag=append bs=1 count=$((32*1024))
@@ -63,9 +63,9 @@ cat << EOF > ${IMAGE}.json-signature
   "signature": "$(base64 -w0 ${IMAGE}.signature)",
   "howto-verify": [
     "base64 -d <certificate>",
-    "base64 -d <signature>"
+    "base64 -d <signature>",
     "openssl verify -CAfile <CERN CA Chain cern.ch/ca> <certificate>",
-    "openssl x509 -in <certificate> -subject -noout | awk '{print \$2}' == ${DN}"
+    "openssl x509 -in <certificate> -subject -noout | awk '{print \$2}' == ${DN}",
     "openssl x509 -in <certificate> -pubkey -noout > <pubkey>",
     "openssl dgst -sha256 -verify <pubkey> -signature <signature> \$(head -c -$((32*1024)) <image>)"
   ]


### PR DESCRIPTION
Automatic checking of the signatures is now in Vac and Vcycle, but to do this I had to put in some replace() calls to fix the above commas in the uCernVM images they download. Changing your script will resolve this for future versions you build? Thanks, Andrew